### PR TITLE
release 3.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rat" %}
-{% set version = "3.0.2" %}
+{% set version = "3.0.3" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rat" %}
-{% set version = "3.0.1" %}
+{% set version = "3.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/rat-{{ version }}.tar.gz
-  sha256: c1718857affdf5d8e97eb3a0fdf895c61097a5c02551a6ef71ef8ffea46c2ced
+  sha256: cdd9ef1131b781eed7c1bb15654b743338b5daf7136a92baf2f665555ee1dad7
 
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 2
+  number: 0
   entry_points:
     - rat = rat.cli.rat_cli:main
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
Bug Fixes:

TMS-OS will work after 2019
TMS-OS will make use of Optical data to estimate surface area of reservoirs if SAR is not available or if Optical is much more than SAR.
To further smoothen and remove the erroneous peaks rising due to use of optical data, Savitzky-Golay filter is applied for cases mentioned in [2].
TMS-OS will not produce error if end date is before the start of Landsat-9 mission.

Improvements:
Tests will now be matched for numeric data and will be considered as match if the error percent between each value is less than threshold (default - 5) %.
State init files (vic and Routing) can now be provided as optional to dates. Earlier RAT used to assume that the state init files will be existing in a particular directory structure. This will not be true if someone is working on tutorial or want to use state files not produced by RAT.
If State init files are given as complete path, RAT will assume that there is no previous meteorological input data and will create CombinedNC file from scratch.
-->
